### PR TITLE
fix license classification and policy rules - reboot

### DIFF
--- a/evaluator.rules.kts
+++ b/evaluator.rules.kts
@@ -30,6 +30,9 @@ val orgName = "Example Inc."
 val orgScanIssueTrackerName = "FOSS JIRA"
 val orgScanIssueTrackerMdLink = "[$orgScanIssueTrackerName](https://jira.example.com/FOSS)"
 
+val disableHowToFix = (System.getenv("ORT_EVALUATOR_HOWTOFIX_DISABLE") == "true")
+val disabledHowToFixText = "Check with your compliance team to resolve this issue."
+
 /**
  * Import the license classifications from license-classifications.yml.
  */
@@ -299,7 +302,13 @@ fun PackageRule.howToFixLicenseViolationDefault(
     license: String,
     licenseSource: LicenseSource
 ): String {
+
+    if (disableHowToFix) {
+        return disabledHowToFixText
+    }
+
     if (ortResult.isProject(pkg.metadata.id)) {
+
         // Violation is flagged for the project scanned.
         if (licenseSource == LicenseSource.DETECTED) {
             // License is detected by the scanner in the source code of the project.
@@ -324,6 +333,9 @@ fun PackageRule.howToFixUnhandledLicense(
     license: String,
     licenseSource: LicenseSource
 ) : String {
+    if (disableHowToFix) {
+        return disabledHowToFixText
+    }
     val createIssueText = """
         |1. If an issue to add this license does not already exist in $orgScanIssueTrackerMdLink, please create it.
         |2. Set the _Summary_ field to 'Add new license $license'.
@@ -380,6 +392,11 @@ fun PackageRule.howToFixOssProjectDefault() = """
     """.trimIndent()
 
 fun PackageRule.howToFixUnmappedDeclaredLicense(license: String): String {
+
+    if (disableHowToFix) {
+        return disabledHowToFixText
+    }
+
     val genericDeclaredLicenses = setOf(
         "BSD License",
         "The BSD License"
@@ -612,7 +629,7 @@ fun resolveViolationInDependencySourceCodeText(pkg: Package, license: String) : 
             |Try to resolve this violation by following the advice below:
             |
             |1. Clone $ortConfigVcsMdLink using Git.
-            |2. Download and extract:  
+            |2. Download and extract:
             |   - $binaryUrlMdLink
             |   - $sourcesUrlMdLink
             |4. Find the lines which triggered this violation:
@@ -738,7 +755,7 @@ fun resolveViolationInDependencySourceCodeText(pkg: Package, license: String) : 
             !   - Expand the _Scan Results_ section  under '${pkg.id.toCoordinates()}' in `*-scan-report-web-app.html`
             |   - Filter the _Value_ column, selecting only the licenses to which the violation refers
             |4. Open the $vcsUrlMdLink in a web browser and find the source code for version `${pkg.id.version}`.
-            |5. If the extracted $binaryUrlMdLink contains fewer files or directories than shown under 
+            |5. If the extracted $binaryUrlMdLink contains fewer files or directories than shown under
             |   the _Scan Results_ for '${pkg.id.toCoordinates()}' in `*-scan-report-web-app.html`, you may need to
             |   limit the number of files/directories the scanner scans. For example, if the repository contains other
             |   packages and not just '${pkg.id.toCoordinates()}':
@@ -774,7 +791,7 @@ fun resolveViolationInDependencySourceCodeText(pkg: Package, license: String) : 
             |6. If there are license file findings for '${pkg.id.toCoordinates()}' in directories in $vcsUrlMdLink but not in the extracted $binaryUrlMdLink:
             |   - Create a directory `${getPackageConfigurationFilePath(pkg.id)}` with a file named `vcs.yml`.
             |   - Open `vcs.yml` in a text editor.
-            |   - For each _directory_ found in the $vcsUrlMdLink but not in extracted $binaryUrlMdLink, add a $ortPackageConfigurationFileMdLink entry 
+            |   - For each _directory_ found in the $vcsUrlMdLink but not in extracted $binaryUrlMdLink, add a $ortPackageConfigurationFileMdLink entry
             |     with a $ortYmlFilePathExcludeMdLink.
             |     .
             |     Use the following template, changing the text in square brackets (`[...]`) as appropriate.
@@ -919,7 +936,7 @@ fun resolveViolationInDependencySourceCodeText(pkg: Package, license: String) : 
             |5. If there are license findings for '${pkg.id.toCoordinates()}' in directories in $vcsUrlMdLink used only for building or testing the code:
             |   - Create a directory `${getPackageConfigurationFilePath(pkg.id)}` with a file named `vcs.yml`.
             |   - Open `vcs.yml` in a text editor.
-            |   - For each _directory_ found in the $vcsUrlMdLink, but not in extracted $binaryUrlMdLink, add a 
+            |   - For each _directory_ found in the $vcsUrlMdLink, but not in extracted $binaryUrlMdLink, add a
             |     $ortPackageConfigurationFileMdLink entry with a $ortYmlFilePathExcludeMdLink.
             |     Use the following template, changing the text in square brackets (`[...]`) as appropriate.
             |

--- a/evaluator.rules.kts
+++ b/evaluator.rules.kts
@@ -44,6 +44,7 @@ val commercialLicenses = getLicensesForCategory("commercial")
 val copyleftLicenses = getLicensesForCategory("copyleft")
 val copyleftLimitedLicenses = getLicensesForCategory("copyleft-limited")
 val freeRestrictedLicenses = getLicensesForCategory("free-restricted")
+val freeRestrictedCopyleftLicenses = getLicensesForCategory("free-restricted-copyleft")
 val genericLicenses = getLicensesForCategory("generic")
 val patentLicenses = getLicensesForCategory("patent-license")
 val permissiveLicenses = getLicensesForCategory("permissive")
@@ -93,6 +94,7 @@ val handledLicenses = listOf(
     copyleftLicenses,
     copyleftLimitedLicenses,
     freeRestrictedLicenses,
+    freeRestrictedCopyleftLicenses,
     genericLicenses,
     patentLicenses,
     permissiveLicenses,
@@ -1093,6 +1095,13 @@ fun PackageRule.LicenseRule.isFreeRestricted() =
         override fun matches() = license in freeRestrictedLicenses
     }
 
+fun PackageRule.LicenseRule.isFreeRestrictedCopyleft() =
+    object : RuleMatcher {
+        override val description = "isFreeRestrictedCopyleft($license)"
+
+        override fun matches() = license in freeRestrictedCopyleftLicenses
+    }
+
 fun PackageRule.LicenseRule.isGeneric() =
     object : RuleMatcher {
         override val description = "isGeneric($license)"
@@ -1314,6 +1323,26 @@ fun RuleSet.freeRestrictedInDependencyRule() = packageRule("FREE_RESTRICTED_IN_D
 
         error(
             "The dependency '${pkg.metadata.id.toCoordinates()}' is licensed under the ScanCode 'free-restricted' " +
+                    "categorized license $license. This requires approval.",
+            howToFixLicenseViolationDefault(license.toString(), licenseSource)
+        )
+    }
+}
+
+fun RuleSet.freeRestrictedCopyleftInDependencyRule() = packageRule("FREE_RESTRICTED_COPYLEFT_IN_DEPENDENCY") {
+    require {
+        -isProject()
+        -isExcluded()
+    }
+
+    licenseRule("FREE_RESTRICTED_COPYLEFT_IN_DEPENDENCY", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+        require {
+            +isFreeRestrictedCopyleft()
+            -isExcluded()
+        }
+
+        error(
+            "The dependency '${pkg.metadata.id.toCoordinates()}' is licensed under the ScanCode 'free-restricted-copyleft' " +
                     "categorized license $license. This requires approval.",
             howToFixLicenseViolationDefault(license.toString(), licenseSource)
         )
@@ -1735,6 +1764,7 @@ fun RuleSet.proprietaryProjectRules() {
     copyleftInDependencyRule()
     copyleftLimitedInDependencyRule()
     freeRestrictedInDependencyRule()
+    freeRestrictedCopyleftInDependencyRule()
     genericInDependencyRule()
     patentInDependencyRule()
     proprietaryFreeInDependencyRule()

--- a/evaluator.rules.kts
+++ b/evaluator.rules.kts
@@ -1,4 +1,4 @@
-/*
+/* Copyright (C) 2024-2025 Alberto Pianon <pianon@array.eu>
  * Copyright (C) 2019 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort-config/blob/main/NOTICE>)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/evaluator.rules.kts
+++ b/evaluator.rules.kts
@@ -1723,6 +1723,210 @@ fun RuleSet.wrongLicenseInLicenseFileRule() = projectSourceRule("WRONG_LICENSE_I
     }
 }
 
+fun RuleSet.commercialInSourceRule() = packageRule("COMMERCIAL_IN_SOURCE") {
+    require {
+        +isProject()
+        -isExcluded()
+    }
+
+    licenseRule("COMMERCIAL_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+        require {
+            +isCommercial()
+            -isExcluded()
+        }
+
+        error(
+            "Some code in project sources is licensed under the ScanCode 'commercial' " +
+                    "categorized license $license. This requires approval.",
+            howToFixLicenseViolationDefault(license.toString(), licenseSource)
+        )
+    }
+}
+
+fun RuleSet.freeRestrictedInSourceRule() = packageRule("FREE_RESTRICTED_IN_SOURCE") {
+    require {
+        +isProject()
+        -isExcluded()
+    }
+
+    licenseRule("FREE_RESTRICTED_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+        require {
+            +isFreeRestricted()
+            -isExcluded()
+        }
+
+        error(
+            "Some code in project sources is licensed under the ScanCode 'free-restricted' " +
+                    "categorized license $license. This requires approval.",
+            howToFixLicenseViolationDefault(license.toString(), licenseSource)
+        )
+    }
+}
+
+fun RuleSet.freeRestrictedCopyleftInSourceRule() = packageRule("FREE_RESTRICTED_COPYLEFT_IN_SOURCE") {
+    require {
+        +isProject()
+        -isExcluded()
+    }
+
+    licenseRule("FREE_RESTRICTED_COPYLEFT_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+        require {
+            +isFreeRestrictedCopyleft()
+            -isExcluded()
+        }
+
+        error(
+            "Some code in project sources is licensed under the ScanCode 'free-restricted-copyleft' " +
+                    "categorized license $license. This requires approval.",
+            howToFixLicenseViolationDefault(license.toString(), licenseSource)
+        )
+    }
+}
+
+fun RuleSet.genericInSourceRule() = packageRule("GENERIC_IN_SOURCE") {
+    require {
+        +isProject()
+        -isExcluded()
+    }
+
+    licenseRule("GENERIC_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+        require {
+            +isGeneric()
+            -isExcluded()
+            -isIgnored()
+        }
+
+        error(
+            "Some code in project sources might contain a license which is unknown to the " +
+                    " tooling. It was detected as $license which is just a trigger, but not a real license. Please " +
+                    "create a dedicated license identifier if the finding is valid.",
+            howToFixLicenseViolationDefault(license.toString(), licenseSource)
+        )
+    }
+}
+
+fun RuleSet.patentInSourceRule() = packageRule("PATENT_IN_SOURCE") {
+    require {
+        +isProject()
+        -isExcluded()
+    }
+
+    licenseRule("PATENT_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+        require {
+            +isPatent()
+            -isExcluded()
+        }
+
+        error(
+            "Some code in project sources is licensed under the ScanCode 'patent-license' " +
+                    "categorized license $license. This requires approval.",
+            howToFixLicenseViolationDefault(license.toString(), licenseSource)
+        )
+    }
+}
+
+fun RuleSet.proprietaryFreeInSourceRule() = packageRule("PROPRIETARY_FREE_IN_SOURCE") {
+    require {
+        +isProject()
+        -isExcluded()
+    }
+
+    licenseRule("PROPRIETARY_FREE_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+        require {
+            +isProprietaryFree()
+            -isExcluded()
+        }
+
+        error(
+            "Some code in project sources is licensed under the ScanCode 'proprietary-free' " +
+                    "categorized license $license. This requires approval.",
+            howToFixLicenseViolationDefault(license.toString(), licenseSource)
+        )
+    }
+}
+
+fun RuleSet.proprietaryInSourceRule() = packageRule("PROPRIETARY_IN_SOURCE") {
+    require {
+        +isProject()
+        -isExcluded()
+    }
+
+    licenseRule("PROPRIETARY_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+        require {
+            +isProprietary()
+            -isExcluded()
+        }
+
+        error(
+            "Some code in project sources is licensed under the ScanCode 'proprietary' " +
+                    "categorized license $license. This requires approval.",
+            howToFixLicenseViolationDefault(license.toString(), licenseSource)
+        )
+    }
+}
+
+fun RuleSet.sourceavailableInSourceRule() = packageRule("SOURCE_AVAILABLE_IN_SOURCE") {
+    require {
+        +isProject()
+        -isExcluded()
+    }
+
+    licenseRule("SOURCE_AVAILABLE_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+        require {
+            +isSourceavailable()
+            -isExcluded()
+        }
+
+        error(
+            "Some code in project sources is licensed under the ScanCode 'source-available' " +
+                    "categorized license $license. This requires approval.",
+            howToFixLicenseViolationDefault(license.toString(), licenseSource)
+        )
+    }
+}
+
+fun RuleSet.unkownInSourceRule() = packageRule("UNKNOWN_IN_SOURCE") {
+    require {
+        +isProject()
+        -isExcluded()
+    }
+
+    licenseRule("UNKNOWN_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+        require {
+            +isUnknown()
+            -isIgnored()
+            -isExcluded()
+        }
+
+        error(
+            "Some code in project sources might contain a license which is unknown to the " +
+                    " tooling. It was detected as $license which is just a trigger, but not a real license. Please " +
+                    "create a dedicated license identifier if the finding is valid.",
+            howToFixLicenseViolationDefault(license.toString(), licenseSource)
+        )
+    }
+}
+
+fun RuleSet.unstatedInSourceRule() = packageRule("UNSTATED_IN_SOURCE") {
+    require {
+        +isProject()
+        -isExcluded()
+    }
+
+    licenseRule("UNSTATED_IN_SOURCE", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+        require {
+            +isUnstated()
+            -isExcluded()
+        }
+
+        error(
+            "Some code in project sources is licensed under the ScanCode 'unstated-licenses' " +
+                    "categorized license $license. This requires approval.",
+            howToFixLicenseViolationDefault(license.toString(), licenseSource)
+        )
+    }
+}
+
 fun RuleSet.commonRules() {
     unhandledLicenseRule()
     unmappedDeclaredLicenseRule()
@@ -1760,6 +1964,16 @@ fun RuleSet.proprietaryProjectRules() {
     // Rules for project sources:
     copyleftInSourceRule()
     copyleftLimitedInSourceRule()
+    commercialInSourceRule()
+    freeRestrictedInSourceRule()
+    freeRestrictedCopyleftInSourceRule()
+    genericInSourceRule()
+    patentInSourceRule()
+    proprietaryFreeInSourceRule()
+    proprietaryInSourceRule()
+    sourceavailableInSourceRule()
+    unkownInSourceRule()
+    unstatedInSourceRule()
 
     // Rules for dependencies:
     commercialInDependencyRule()

--- a/evaluator.rules.kts
+++ b/evaluator.rules.kts
@@ -54,6 +54,7 @@ val sourceavailableLicenses = getLicensesForCategory("source-available")
 val publicDomainLicenses = getLicensesForCategory("public-domain")
 val unknownLicenses = getLicensesForCategory("unknown")
 val unstatedLicenses = getLicensesForCategory("unstated-license")
+val noassertionLicenses = getLicensesForCategory("noassertion")
 
 // Set of licenses, which are not acted upon by the below policy rules.
 val ignoredLicenses = listOf(
@@ -103,7 +104,8 @@ val handledLicenses = listOf(
     sourceavailableLicenses,
     publicDomainLicenses,
     unknownLicenses,
-    unstatedLicenses
+    unstatedLicenses,
+    noassertionLicenses
 ).flatten().let {
     it.getDuplicates().let { duplicates ->
         require(duplicates.isEmpty()) {

--- a/evaluator.rules.kts
+++ b/evaluator.rules.kts
@@ -48,6 +48,8 @@ val genericLicenses = getLicensesForCategory("generic")
 val patentLicenses = getLicensesForCategory("patent-license")
 val permissiveLicenses = getLicensesForCategory("permissive")
 val proprietaryFreeLicenses = getLicensesForCategory("proprietary-free")
+val proprietaryLicenses = getLicensesForCategory("proprietary")
+val sourceavailableLicenses = getLicensesForCategory("source-available")
 val publicDomainLicenses = getLicensesForCategory("public-domain")
 val unknownLicenses = getLicensesForCategory("unknown")
 val unstatedLicenses = getLicensesForCategory("unstated-license")
@@ -95,6 +97,8 @@ val handledLicenses = listOf(
     patentLicenses,
     permissiveLicenses,
     proprietaryFreeLicenses,
+    proprietaryLicenses,
+    sourceavailableLicenses,
     publicDomainLicenses,
     unknownLicenses,
     unstatedLicenses
@@ -1110,6 +1114,20 @@ fun PackageRule.LicenseRule.isProprietaryFree() =
         override fun matches() = license in proprietaryFreeLicenses
     }
 
+fun PackageRule.LicenseRule.isProprietary() =
+    object : RuleMatcher {
+        override val description = "isProprietary($license)"
+
+        override fun matches() = license in proprietaryLicenses
+    }
+
+fun PackageRule.LicenseRule.isSourceavailable() =
+    object : RuleMatcher {
+        override val description = "isSourceavailable($license)"
+
+        override fun matches() = license in sourceavailableLicenses
+    }
+
 fun PackageRule.LicenseRule.isPatent() =
     object : RuleMatcher {
         override val description = "isPatent($license)"
@@ -1484,6 +1502,46 @@ fun RuleSet.proprietaryFreeInDependencyRule() = packageRule("PROPRIETARY_FREE_IN
     }
 }
 
+fun RuleSet.proprietaryInDependencyRule() = packageRule("PROPRIETARY_IN_DEPENDENCY") {
+    require {
+        -isProject()
+        -isExcluded()
+    }
+
+    licenseRule("PROPRIETARY_IN_DEPENDENCY", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+        require {
+            +isProprietary()
+            -isExcluded()
+        }
+
+        error(
+            "The dependency '${pkg.metadata.id.toCoordinates()}' is licensed under the ScanCode 'proprietary' " +
+                    "categorized license $license. This requires approval.",
+            howToFixLicenseViolationDefault(license.toString(), licenseSource)
+        )
+    }
+}
+
+fun RuleSet.sourceavailableInDependencyRule() = packageRule("SOURCE_AVAILABLE_IN_DEPENDENCY") {
+    require {
+        -isProject()
+        -isExcluded()
+    }
+
+    licenseRule("SOURCE_AVAILABLE_IN_DEPENDENCY", LicenseView.CONCLUDED_OR_DECLARED_AND_DETECTED) {
+        require {
+            +isSourceavailable()
+            -isExcluded()
+        }
+
+        error(
+            "The dependency '${pkg.metadata.id.toCoordinates()}' is licensed under the ScanCode 'source-available' " +
+                    "categorized license $license. This requires approval.",
+            howToFixLicenseViolationDefault(license.toString(), licenseSource)
+        )
+    }
+}
+
 fun RuleSet.unkownInDependencyRule() = packageRule("UNKNOWN_IN_DEPENDENCY") {
     require {
         -isProject()
@@ -1680,6 +1738,8 @@ fun RuleSet.proprietaryProjectRules() {
     genericInDependencyRule()
     patentInDependencyRule()
     proprietaryFreeInDependencyRule()
+    proprietaryInDependencyRule()
+    sourceavailableInDependencyRule()
     unkownInDependencyRule()
     unstatedInDependencyRule()
 }

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -8677,7 +8677,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-saxix-mit"
   categories:
-  - "proprietary-free"
+  - "free-restricted"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-saxpath"
   categories:

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -1487,6 +1487,11 @@ categorizations:
   - "copyleft-limited"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "LLGPL"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "LOOP"
   categories:
   - "permissive"
@@ -6004,6 +6009,11 @@ categorizations:
   categories:
   - "proprietary-free"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-llgpl"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-llnl"
   categories:
   - "permissive"

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -1137,6 +1137,11 @@ categorizations:
   - "copyleft"
   - "include-in-notice-file"
   - "include-source-code-offer-in-notice-file"
+- id: "GPL-2.0 WITH Classpath-exception-2.0"
+  categories:
+  - "copyleft-limited"
+  - "include-in-notice-file"
+  - "include-source-code-offer-in-notice-file"
 - id: "GPL-2.0-only"
   categories:
   - "copyleft"

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -1420,7 +1420,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "JSON"
   categories:
-  - "permissive"
+  - "free-restricted"
   - "include-in-notice-file"
 - id: "Jam"
   categories:
@@ -5626,7 +5626,7 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-json"
   categories:
-  - "permissive"
+  - "free-restricted"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-json-js-pd"
   categories:

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -18,6 +18,7 @@ categories:
 - name: "copyleft"
 - name: "copyleft-limited"
 - name: "free-restricted"
+- name: "free-restricted-copyleft"
 - name: "generic"
 - name: "include-in-notice-file"
 - name: "include-source-code-offer-in-notice-file"
@@ -498,170 +499,160 @@ categorizations:
   - "include-in-notice-file"
 - id: "CC-BY-NC-1.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-NC-2.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-NC-2.5"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-NC-3.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-NC-3.0-DE"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-NC-4.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-NC-ND-1.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-NC-ND-2.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-NC-ND-2.5"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-NC-ND-3.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-NC-ND-3.0-DE"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-NC-ND-3.0-IGO"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-NC-ND-4.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-NC-SA-1.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "CC-BY-NC-SA-2.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "CC-BY-NC-SA-2.0-DE"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "CC-BY-NC-SA-2.0-FR"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "CC-BY-NC-SA-2.0-UK"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "CC-BY-NC-SA-2.5"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "CC-BY-NC-SA-3.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "CC-BY-NC-SA-3.0-DE"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "CC-BY-NC-SA-3.0-IGO"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "CC-BY-NC-SA-4.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "CC-BY-ND-1.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-ND-2.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-ND-2.5"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-ND-3.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-ND-3.0-DE"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-ND-4.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "CC-BY-SA-1.0"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "CC-BY-SA-2.0"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "CC-BY-SA-2.0-UK"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "CC-BY-SA-2.1-JP"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "CC-BY-SA-2.5"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "CC-BY-SA-3.0"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "CC-BY-SA-3.0-AT"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "CC-BY-SA-3.0-DE"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "CC-BY-SA-3.0-IGO"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "CC-BY-SA-4.0"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "CC-PDDC"
   categories:
   - "public-domain"
@@ -674,7 +665,6 @@ categorizations:
   categories:
   - "copyleft"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "CC0-1.0"
   categories:
   - "public-domain"
@@ -2911,182 +2901,172 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-cc-by-nc-1.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nc-2.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nc-2.5"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nc-3.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nc-3.0-de"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nc-4.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nc-nd-1.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nc-nd-2.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nc-nd-2.0-at"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nc-nd-2.0-au"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nc-nd-2.5"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nc-nd-3.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nc-nd-3.0-de"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nc-nd-3.0-igo"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nc-nd-4.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nc-sa-1.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "LicenseRef-scancode-cc-by-nc-sa-2.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "LicenseRef-scancode-cc-by-nc-sa-2.0-de"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "LicenseRef-scancode-cc-by-nc-sa-2.0-fr"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "LicenseRef-scancode-cc-by-nc-sa-2.0-uk"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "LicenseRef-scancode-cc-by-nc-sa-2.5"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "LicenseRef-scancode-cc-by-nc-sa-3.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "LicenseRef-scancode-cc-by-nc-sa-3.0-de"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "LicenseRef-scancode-cc-by-nc-sa-3.0-igo"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "LicenseRef-scancode-cc-by-nc-sa-3.0-us"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "LicenseRef-scancode-cc-by-nc-sa-4.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted-copyleft"
 - id: "LicenseRef-scancode-cc-by-nd-1.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nd-2.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nd-2.5"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nd-3.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nd-3.0-de"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-nd-4.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-by-sa-1.0"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "LicenseRef-scancode-cc-by-sa-2.0"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "LicenseRef-scancode-cc-by-sa-2.0-uk"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "LicenseRef-scancode-cc-by-sa-2.1-jp"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "LicenseRef-scancode-cc-by-sa-2.5"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "LicenseRef-scancode-cc-by-sa-3.0"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "LicenseRef-scancode-cc-by-sa-3.0-at"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "LicenseRef-scancode-cc-by-sa-3.0-de"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "LicenseRef-scancode-cc-by-sa-3.0-igo"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "LicenseRef-scancode-cc-by-sa-4.0"
   categories:
-  - "copyleft-limited"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
+  - "copyleft"
 - id: "LicenseRef-scancode-cc-devnations-2.0"
   categories:
   - "proprietary-free"
@@ -3103,16 +3083,16 @@ categorizations:
   - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-cc-nc-1.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-nc-sampling-plus-1.0"
   categories:
-  - "proprietary-free"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-nd-1.0"
   categories:
-  - "source-available"
   - "include-in-notice-file"
+  - "free-restricted"
 - id: "LicenseRef-scancode-cc-pd"
   categories:
   - "public-domain"
@@ -3125,7 +3105,6 @@ categorizations:
   categories:
   - "copyleft"
   - "include-in-notice-file"
-  - "include-source-code-offer-in-notice-file"
 - id: "LicenseRef-scancode-cc-sampling-1.0"
   categories:
   - "proprietary-free"

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -24,6 +24,7 @@ categories:
 - name: "patent-license"
 - name: "permissive"
 - name: "proprietary-free"
+- name: "proprietary"
 - name: "public-domain"
 - name: "source-available"
 - name: "unknown"
@@ -8250,10 +8251,10 @@ categorizations:
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-proprietary"
   categories:
-  - "generic"
+  - "proprietary"
 - id: "LicenseRef-scancode-proprietary-license"
   categories:
-  - "generic"
+  - "proprietary"
 - id: "LicenseRef-scancode-prosperity-1.0.1"
   categories:
   - "proprietary-free"

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -3951,6 +3951,9 @@ categorizations:
   categories:
   - "free-restricted"
   - "include-in-notice-file"
+- id: "LicenseRef-scancode-ecma-no-patent"
+  categories:
+  - "patent-license"
 - id: "LicenseRef-scancode-ecma-patent-coc-0"
   categories:
   - "proprietary-free"

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -29,6 +29,7 @@ categories:
 - name: "source-available"
 - name: "unknown"
 - name: "unstated-license"
+- name: "noassertion"
 categorizations:
 - id: "0BSD"
   categories:
@@ -10676,6 +10677,9 @@ categorizations:
   categories:
   - "public-domain"
   - "include-in-notice-file"
+- id: "NOASSERTION"
+  categories:
+  - "noassertion"
 - id: "NOSL"
   categories:
   - "copyleft-limited"

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -9781,11 +9781,11 @@ categorizations:
   - "generic"
 - id: "LicenseRef-scancode-unrar"
   categories:
-  - "source-available"
+  - "free-restricted"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-unrar-v3"
   categories:
-  - "source-available"
+  - "free-restricted"
   - "include-in-notice-file"
 - id: "LicenseRef-scancode-unsplash"
   categories:

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -10713,6 +10713,10 @@ categorizations:
   categories:
   - "permissive"
   - "include-in-notice-file"
+- id: "Net-SNMP"
+  categories:
+  - "permissive"
+  - "include-in-notice-file"
 - id: "NetCDF"
   categories:
   - "permissive"


### PR DESCRIPTION
I realized that the fix for CC licenses in my previous PR #1 wouldn't work with the standard logic of ORT evaluator's policy rules.

We had concluded that CC-(ND|NC)-SA-* licenses are both "copyleft" and "free-restricted", and categorized them accordingly.

However, the logic of the standard evaluator.rules.kts does not allow to have multiple categories for the same license, which may trigger multiple rules for the same license; particularly, ORT would return a duplicate license error.

Therefore I created a dedicated "free-restricted-copyleft" category in license-classification.yml, with the necessary handler and policy rule in evaluator.rules.kts, and I recreated the whole chain of commits, to have a clean git history
